### PR TITLE
Limit image optimizations to 10 at a time

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
 
         grunt.verbose.writeflags(options, 'Options');
 
-        grunt.util.async.forEachLimit(this.files, 10, function (files, next) {
+        grunt.util.async.forEachLimit(this.files, 30, function (files, next) {
             files.src.forEach(function (src) {
                 var dest = files.dest;
                 if (path.extname(dest) === '') {


### PR DESCRIPTION
I saw Issue #13 after having had the same issue myself. 

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
```

This seems to fix the problem for me, though it doesn't mean that there isn't a better fix out there involving `removeAllListeners` or something.
