### PR TITLE
Indention is inconsistent between app and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/test/imagemin_test.js
+++ b/test/imagemin_test.js
@@ -3,22 +3,22 @@ var grunt = require('grunt');
 var fs = require('fs');
 
 exports.imagemin = {
-  minifyPng: function (test) {
-    test.expect(1);
+    minifyPng: function (test) {
+        test.expect(1);
 
-    var actual = fs.statSync('tmp/test.png').size;
-    var original = fs.statSync('test/fixtures/test.png').size;
-    test.ok(actual < original, 'should minify PNG images');
+        var actual = fs.statSync('tmp/test.png').size;
+        var original = fs.statSync('test/fixtures/test.png').size;
+        test.ok(actual < original, 'should minify PNG images');
 
-    test.done();
-  },
-  minifyJpg: function (test) {
-    test.expect(1);
+        test.done();
+    },
+    minifyJpg: function (test) {
+        test.expect(1);
 
-    var actual = fs.statSync('tmp/test.jpg').size;
-    var original = fs.statSync('test/fixtures/test.jpg').size;
-    test.ok(actual < original, 'should minify JPG images');
+        var actual = fs.statSync('tmp/test.jpg').size;
+        var original = fs.statSync('test/fixtures/test.jpg').size;
+        test.ok(actual < original, 'should minify JPG images');
 
-    test.done();
-  }
+        test.done();
+    }
 };


### PR DESCRIPTION
Editoconfig says 2 spaces, app code uses 4, tests use 4. Since the majority uses 4 I updated the tests and the editorconfig to reflect that. Let me know if you'd rather have it the other way around.
