### PR TITLE
Allow overwriting the src file with optimized version

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -69,7 +69,7 @@ module.exports = function (grunt) {
             if (path.extname(src) === '.png') {
                 // OptiPNG can't overwrite without creating a backup file
                 // https://sourceforge.net/tracker/?func=detail&aid=3607244&group_id=151404&atid=780913
-                if (grunt.file.exists(dest)) {
+                if (dest !== src && grunt.file.exists(dest)) {
                     grunt.file.delete(dest);
                 }
 


### PR DESCRIPTION
Fixes "Fatal error: ENOENT, no such file or directory" when src and dest are the same.

``` javascript
grunt.initConfig({
    imagemin: {
        icons: {
            options: { optimizationLevel:3 },
            files: [ {
                expand:true, cwd:'public/image/',
                src:'**/*.png', dest:'public/image/'
            } ]
        }
    }
});
```
