### PR TITLE
Fix path.join error with node 0.10

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -35,7 +35,7 @@ module.exports = function (grunt) {
             files.src.forEach(function (src) {
                 var dest = files.dest;
                 if (path.extname(dest) === '') {
-                    dest = path.join(dest, path.basename(src));
+                    dest = path.join(dest || '', path.basename(src));
                 }
                 optimize(src, dest, next);
             });


### PR DESCRIPTION
Fixes a common error with latest nodejs where the grunt task crashes due to warning

```
Warning: Arguments to path.join must be strings Use --force to continue.
```
