### PR TITLE
Add support for pngquant

### DIFF
--- a/docs/imagemin-options.md
+++ b/docs/imagemin-options.md
@@ -29,3 +29,13 @@ Type: `Boolean`
 Default: `true`
 
 Lossless conversion to progressive.
+
+
+## pngquant
+
+Type: `Boolean`
+Default: `true`
+
+Whether to enable pngquant compression.
+
+> pngquant is a command-line utility for converting 24/32-bit PNG images to paletted (8-bit) PNGs. The conversion reduces file sizes significantly (often as much as 70%) and preserves full alpha transparency.

--- a/docs/imagemin-overview.md
+++ b/docs/imagemin-overview.md
@@ -1,5 +1,5 @@
 Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
 
-Minify images using [OptiPNG](http://optipng.sourceforge.net), [jpegtran](http://jpegclub.org/jpegtran/) and [gifsicle](http://www.lcdf.org/gifsicle).
+Minify images using [OptiPNG](http://optipng.sourceforge.net), [pngquant](http://pngquant.org), [jpegtran](http://jpegclub.org/jpegtran/) and [gifsicle](http://www.lcdf.org/gifsicle).
 
 Images will be cached and only minified again if they change.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jpegtran-bin": "~0.1.0",
     "optipng-bin": "~0.2.0",
     "gifsicle": "~0.1.0",
+    "pngquant-bin": "~0.1.0",
     "chalk": "~0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pretty rough implementation of pngquant but it works and the results are impressive:
- With optipng alone: `test/fixtures/test.png (saved 10.15 kB)`
- With optipng + pngquant: `test/fixtures/test.png (saved 42.28 kB)`

There's one problem with caching though. Since the caching is done in `processed()` we might have to move it out to a separate function or something so that we can cache the pngquant images instead of the optipng ones.
