### PR TITLE
The old jpegtran-bin and optipng-bin don't work on sunos

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "filesize": "~1.10.0",
-    "jpegtran-bin": "~0.1.0",
-    "optipng-bin": "~0.2.0",
+    "jpegtran-bin": "~0.2.0",
+    "optipng-bin": "~0.3.0",
     "gifsicle": "~0.1.0",
     "pngquant-bin": "~0.1.0",
     "chalk": "~0.2.0"


### PR DESCRIPTION
I submitted fixes for both of them, so it would be nice if we could reference them so that yeoman projects install properly on sunos.
