### PR TITLE
Pointing to specific version of pngquant-bin to fix ENOENT error on more...

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jpegtran-bin": "~0.2.0",
     "optipng-bin": "~0.3.0",
     "gifsicle": "~0.1.0",
-    "pngquant-bin": "~0.1.0",
+    "pngquant-bin": "0.1.3",
     "chalk": "~0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This addresses bug #96.
