### PR TITLE
Updated pngquant-bin to fix spawn ENOENT error

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jpegtran-bin": "~0.2.0",
     "optipng-bin": "~0.3.0",
     "gifsicle": "~0.1.0",
-    "pngquant-bin": "~0.1.0",
+    "pngquant-bin": "~0.1.5",
     "chalk": "~0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To address [#96](https://github.com/gruntjs/grunt-contrib-imagemin/issues/96)
