### PR TITLE
Completes feature request #114 - showing percentage of file size saved in compression

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -76,7 +76,7 @@ module.exports = function (grunt) {
             var cachePath = path.join(cacheDir, hashFile(src));
 
             function processed(err, result, code) {
-                var newFileSize, saved, savedMsg, percentSaved;
+                var newFileSize, saved, savedMsg, percentSaved = 0;
 
                 if (err) {
                     grunt.log.writeln(err);
@@ -85,7 +85,9 @@ module.exports = function (grunt) {
 				newFileSize = fs.statSync(dest).size;
                 saved = originalSize - newFileSize;
                 totalSaved += saved;
-				percentSaved = (((originalSize - newFileSize) / originalSize) * 100).toFixed(2);
+				if (originalSize != 0) {
+					percentSaved = (((originalSize - newFileSize) / originalSize) * 100).toFixed(2);
+				}
 
                 if (result && (result.stderr.indexOf('already optimized') !== -1 || saved < 10)) {
                     savedMsg = 'already optimized';


### PR DESCRIPTION
In order to give a more relative idea of how well compression is performing, this adds a display of the percentage saved between the original file and compressed file. 
