### PR TITLE
Check if tmp png file exists before deleting. Fixes #104

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -127,7 +127,10 @@ module.exports = function (grunt) {
                             cmd: optipngPath,
                             args: optipngArgs.concat(['-out', dest, tmpDest])
                         }, function () {
-                            grunt.file.delete(tmpDest);
+                            if(grunt.file.exists(tmpDest)){
+                                grunt.file.delete(tmpDest);
+                            }
+                            
                             processed();
                         });
                     });


### PR DESCRIPTION
Since this does seem to be an intermittent issue on 64-Bit Windows, I'm not sure how to write a reliable test for this. 
