### PR TITLE
call grunt.file-delete with {force: true} when deleting intermediate files

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -69,6 +69,12 @@ module.exports = function (grunt) {
             done();
         }.bind(this));
 
+        function deleteTempFile(filepath) {
+            // Pass the "force" flag to allow deleting the file even if it's
+            // outside of the Grunt base directory.
+            grunt.file.delete(filepath, {force: true});
+        }
+
         function optimize(src, dest, next) {
             var cp;
             var originalSize = fs.statSync(src).size;
@@ -120,14 +126,14 @@ module.exports = function (grunt) {
                         args: pngquantArgs
                     }, function () {
                         if (grunt.file.exists(dest)) {
-                            grunt.file.delete(dest);
+                            deleteTempFile(dest);
                         }
 
                         grunt.util.spawn({
                             cmd: optipngPath,
                             args: optipngArgs.concat(['-out', dest, tmpDest])
                         }, function () {
-                            grunt.file.delete(tmpDest);
+                            deleteTempFile(tmpDest);
                             processed();
                         });
                     });
@@ -136,7 +142,7 @@ module.exports = function (grunt) {
                     fs.createReadStream(src).pipe(cp.stdin);
                 } else {
                     if (dest !== src && grunt.file.exists(dest)) {
-                        grunt.file.delete(dest);
+                        deleteTempFile(dest);
                     }
 
                     cp = grunt.util.spawn({


### PR DESCRIPTION
Calls to `grunt.file.delete` blow up when deleting files outside of the Grunt base directory.  This is causing imagemin to fail on my project has the following directory structure:

```
- src
  |-- Gruntfile.js
  |-- foo.png
- build
  |-- foo.png
```

The `grunt.file.delete` safeguard seems reasonable for a task that deletes files that it didn't create.  It doesn't seem helpful for temporary files that are created and deleted all within the lifecycle of a single task invocation.  Pass the `force` flag to `grunt.file.delete` to allow the file deletion even if it's outside the Grunt base directory.
