### PR TITLE
Use specific version of gifsicle to combat building issue on CentOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "filesize": "~2.0.0",
     "jpegtran-bin": "~0.2.0",
     "optipng-bin": "~0.3.0",
-    "gifsicle": "~0.1.0",
+    "gifsicle": "0.1.3",
     "pngquant-bin": "~0.1.0",
     "chalk": "~0.3.0",
     "async": "~0.2.9"


### PR DESCRIPTION
Latest version of gifsicle does not build on CentOS. Reverting to the previous version does.

https://github.com/yeoman/node-gifsicle/issues/11
