### PR TITLE
Avoid blowing up the stack by using `setImmediate()` instead of recursion

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -98,7 +98,7 @@ module.exports = function (grunt) {
                 }
 
                 grunt.log.writeln(chalk.green('✔ ') + src + chalk.gray(' (' + savedMsg + ')'));
-                next();
+                setImmediate(next);
             }
 
             grunt.file.mkdir(path.dirname(dest));


### PR DESCRIPTION
I've bumped into #83 while trying to optimize a folder with ~500 images. Using the proposed fix (but with `setImmediate` instead of `setTimeout`) solved the issue for me.

All tests are passing.
