### PR TITLE
Avoid blowing up the stack by making `processed` synchronous

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -98,7 +98,7 @@ module.exports = function (grunt) {
                 }
 
                 grunt.log.writeln(chalk.green('✔ ') + src + chalk.gray(' (' + savedMsg + ')'));
-                next();
+                process.nextTick(next);
             }
 
             grunt.file.mkdir(path.dirname(dest));


### PR DESCRIPTION
Use `process.nextTick` to make `processed`'s call to `next` synchronous, and thus not blow up the stack by executing too many jobs simultaneously.

Fixes issue #83.
