### PR TITLE
Workaround for pnquant failing on windows by allowing to control parallel processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Whether to enable pngquant compression.
 
 > pngquant is a command-line utility for converting 24/32-bit PNG images to paletted (8-bit) PNGs. The conversion reduces file sizes significantly (often as much as 70%) and preserves full alpha transparency.
 
+
+#### parallel
+
+Type: `Integer`
+Default: number of cores
+
+Parallel processing limit, defaults to the number of cores. Whenever you have intermittent issues with
+optimizers, try setting this to 1.
+
+
 #### Example config
 
 You can either map your files statically or [dynamically](https://github.com/gruntjs/grunt/wiki/Configuring-tasks#building-the-files-object-dynamically).

--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -35,7 +35,8 @@ module.exports = function (grunt) {
         var options = this.options({
             optimizationLevel: 7,
             progressive: true,
-            pngquant: false
+            pngquant: false,
+            ayncLimit: numCPUs
         });
         var optipngArgs = ['-strip', 'all'];
         var pngquantArgs = ['-'];
@@ -55,7 +56,7 @@ module.exports = function (grunt) {
             gifsicleArgs.push('--interlace');
         }
 
-        async.eachLimit(this.files, numCPUs, function (file, next) {
+        async.eachLimit(this.files, options.ayncLimit, function (file, next) {
             optimize(file.src[0], file.dest, next);
         }.bind(this), function (err) {
             if (err) {
@@ -125,7 +126,10 @@ module.exports = function (grunt) {
                         grunt.util.spawn({
                             cmd: optipngPath,
                             args: optipngArgs.concat(['-out', dest, tmpDest])
-                        }, function () {
+                        }, function (err) {
+                            if (err) {
+                                grunt.fail.fatal(err);
+                            }
                             grunt.file.delete(tmpDest);
                             processed();
                         });


### PR DESCRIPTION
Adds option to specify the parallel limit - pngquant sometimes fails when working in parallel on windows
Additionaly throws a more meaningfull error if pngquant or optipng fails

Solves #69

To work around the windows issue, or just to control the parallelism, use this:

```
        imagemin: {
            options: {
                parallel: 1,
                pngquant: true
            },
            ...
        }            
```
