### PR TITLE
add an environment variable option to control cache directory #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ grunt.loadNpmTasks('grunt-contrib-imagemin');
 grunt.registerTask('default', ['imagemin']);
 ```
 
+### Cache
+
+Minimized images will be cached to `os.tmpdir()` directory by default, user can use environment variable `GRUNT_IMAGEMIN_CACHE` to specific another directory to store cached images:
+
+```shell
+echo "export GRUNT_IMAGEMIN_CACHE=$USER/.grunt-images" >> ~/.bash_profile && . ~/.bash_profile
+```
+
+or set this environment variable inline:
+```shell
+GRUNT_IMAGEMIN_CACHE=~/.grunt-images grunt imagemin
+```
 
 ## Release History
 

--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -22,8 +22,12 @@ module.exports = function (grunt) {
     var jpegtranPath;
     var gifsiclePath;
     var numCPUs = os.cpus().length;
-    var tmpdir = os.tmpdir ? os.tmpdir() : os.tmpDir();
-    var cacheDir = path.join(tmpdir, 'grunt-contrib-imagemin.cache');
+
+    var cacheDir = process.env.GRUNT_IMAGEMIN_CACHE;
+    if (!cacheDir) {
+        var tmpdir = os.tmpdir ? os.tmpdir() : os.tmpDir();
+        cacheDir = path.join(tmpdir, 'grunt-contrib-imagemin.cache');
+    }
 
     function hashFile(filePath) {
         var content = grunt.file.read(filePath);


### PR DESCRIPTION
Minimized images will be cached to `os.tmpdir()` directory by default,
user can use environment variable `GRUNT_IMAGEMIN_CACHE` to specific
another directory to store cached images.
