### PR TITLE
Remove 0.8 from the list of Node versions Travis CI tests against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - '0.10'
-  - '0.8'
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
Because this plugin doesn’t support Node v0.8 any longer, according to [this commit](https://github.com/gruntjs/grunt-contrib-imagemin/commit/1291d2806cab842a1c74c5797e594f74136e61af).
