### PR TITLE
FIX repository field on package.json to pass the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
   },
-  "repository": "gruntjs/grunt-contrib-imagemin",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/gruntjs/grunt-contrib-imagemin.git"
+  },
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
Grunt-contrib-imagemin was not being able to build successfuly because on another commit the repository field on package.json was simplified to a string, instead of an object containing url and type of repo, so contrib-build task raised an error trying to work with url field (undefined).
