### PR TITLE
Bump 'image-min' dependency to v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "~0.2.9",
     "chalk": "~0.4.0",
     "filesize": "~2.0.0",
-    "image-min": "~0.1.1"
+    "image-min": "~0.1.3"
   },
   "devDependencies": {
     "cache-file": "~0.1.2",


### PR DESCRIPTION
When using Windows:

`optipng.exe: downloading [====               ] 25% 0.9s✗ pre-build test failed, compiling from source...
✗ building is not supported on win32`

The latest 'image-min' is v0.1.3 does away with the dependency `optipng-bin` in favour of an optional dependency `pngquant-bin`

`grunt-contrib-imagemin` currently has a dependency of `image-min` v0.1.1
- `v~0.1.1` has a dependency on `optipng-bin`
- `v~0.1.2` has `optipng-bin` as an optional dependency 
- `v~0.1.3` removes the `optipng-bin` dependency in favour of `pngquant-bin`

So in theory this should fix this error
