### PR TITLE
Add homepage, repository and bugs information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,18 @@
   "name": "grunt-contrib-imagemin",
   "description": "Minify PNG, JPEG and GIF images",
   "version": "0.5.0",
+  "homepage": "https://github.com/gruntjs/grunt-contrib-imagemin",
   "author": {
     "name": "Grunt Team",
     "url": "http://gruntjs.com/"
   },
-  "repository": "gruntjs/grunt-contrib-imagemin",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/gruntjs/grunt-contrib-imagemin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gruntjs/grunt-contrib-imagemin/issues"
+  },
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
(Note: This is fixing the same problem that [htmlmin also had](https://github.com/gruntjs/grunt-contrib-htmlmin/pull/57). These two contrib plugins seemed to be different than the rest.)

I noticed that the grunt-contrib README list of projects had a [broken/missing link for `grunt-contrib-imagemin`](https://github.com/gruntjs/grunt-contrib#grunt-contrib-imagemin-v050--)

I think I've tracked it down to this project lacking the homepage field in the `package.json`. It also was missing a couple other fields that the other grunt-contrib plugins have.

This pull request adds in those missing fields.
