### PR TITLE
Added option to limit the number of parallel optimization processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Whether to enable pngquant compression.
 
 > pngquant is a command-line utility for converting 24/32-bit PNG images to paletted (8-bit) PNGs. The conversion reduces file sizes significantly (often as much as 70%) and preserves full alpha transparency.
 
+
+#### parallelProcesses
+
+Type: `Int`
+Default: `os.cpus().length`
+
+Restrict parallel processes to the specified number, try setting this value to `1` or `2` if your compressed images are corrupt. This problem has been obeserved on some machines running on multicore processors (8+)
+
 #### Example config
 
 You can either map your files statically or [dynamically](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically).

--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -23,10 +23,11 @@ module.exports = function (grunt) {
         var totalSaved = 0;
         var options = this.options({
             optimizationLevel: 7,
-            progressive: true
+            progressive: true,
+            parallelProcesses : os.cpus().length
         });
 
-        async.forEachLimit(files, os.cpus().length, function (file, next) {
+        async.forEachLimit(files, options.parallelProcesses, function (file, next) {
             var msg;
             options.ext = path.extname(file.src[0]);
 


### PR DESCRIPTION
fixes #196 #184 and I suspect also #193 on multi-core (8+) machines running Win64. 

This change has been tested on my machines which could reproduce all of the above problems before.

Now setting parallelProcesses  to 1 I am not able to reproduce the problems anymore.
