### PR TITLE
Caching original image size before optimization

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -37,13 +37,14 @@ module.exports = function (grunt) {
             if (options.use) {
                 options.use.forEach(imagemin.use.bind(imagemin));
             }
-
+            
+            var origSize = fs.statSync(file.src[0]).size;
+            
             imagemin.optimize(function (err, data) {
                 if (err) {
                     grunt.warn(err);
                 }
 
-                var origSize = fs.statSync(file.src[0]).size;
                 var diffSize = origSize - data.contents.length;
                 totalSaved += diffSize;
 


### PR DESCRIPTION
If the source and destination folder for the tasks are same, then `origSize` is same as the optimized image size(`data.contents.length`). This shows the false message - **_already optimized**_ even when optimization of images has actually taken place.
