### PR TITLE
Options aren't passed to plugin's properly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,9 @@ module.exports = function (grunt) {
       }
     },
     nodeunit: {
-      tests: ['test/test.js']
+      tests: ['test/test.js'],
+      // Has dependencies on ImageMagick
+      progressiveTests: ['test/test-progressive.js']
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-contrib-internal": "^0.4.6",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-nodeunit": "^0.3.3",
+    "imagemagick": "^0.1.3",
     "time-grunt": "^0.3.1"
   },
   "peerDependencies": {

--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -30,9 +30,9 @@ module.exports = function (grunt) {
             var imagemin = new Imagemin()
                 .src(file.src[0])
                 .dest(file.dest)
-                .use(Imagemin.jpegtran(options.progressive))
-                .use(Imagemin.gifsicle(options.interlaced))
-                .use(Imagemin.optipng(options.optimizationLevel));
+                .use(Imagemin.jpegtran(options))
+                .use(Imagemin.gifsicle(options))
+                .use(Imagemin.optipng(options));
 
             if (options.use) {
                 options.use.forEach(imagemin.use.bind(imagemin));

--- a/test/test-progressive.js
+++ b/test/test-progressive.js
@@ -1,0 +1,22 @@
+'use strict';
+var chalk = require('chalk');
+// Has dependencies on ImageMagick
+var im = require('imagemagick');
+
+exports.imagemin = {
+    interlacedJpg: function (test) {
+        test.expect(1);
+
+        im.identify(['-verbose', 'tmp/test.jpg'], function (err, features) {
+            if (err) {
+				test.ok(false, err + chalk.red('Make sure ImageMagick CLI tools are installed'));
+            }
+			else {
+				var interlaceValue = features.match(/Interlace: \w+/)[0].split(' ')[1];
+				test.strictEqual(interlaceValue, 'JPEG', 'should be progressive JPG images');
+			}
+
+			test.done();
+		});
+    }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,7 @@ exports.imagemin = {
 
         var actual = fs.statSync('tmp/test.gif').size;
         var original = fs.statSync('test/fixtures/test.gif').size;
-        test.ok(actual < original, 'should minify GIF images');
+        test.ok(actual <= original, 'should minify GIF images');
 
         test.done();
     },
@@ -55,7 +55,7 @@ exports.imagemin = {
 
         var actual = fs.statSync('tmp/test-uppercase.GIF').size;
         var original = fs.statSync('test/fixtures/test-uppercase.GIF').size;
-        test.ok(actual < original, 'should minify uppercase extension GIF images');
+        test.ok(actual <= original, 'should minify uppercase extension GIF images');
 
         test.done();
     },


### PR DESCRIPTION
It seems that the options like 'interlaced: true' etc. aren't passed to the plugin's in the proper format.
This caused JPG and GIF images not to be converted to be progressive/interlaced and setting optimizationLevel for PNG images didn't have any effect.

I've added a test for JPG images to check if they are progressive but unfortunately it depends on ImageMagick (CLI tools need to be installed on the system). Added it in an external file so it can be easily disabled if ImageMagick isn't available.

I've also updated the test for GIF images because passing the interlaced options keeps it the same size as the original.
