### PR TITLE
Fixed bug with progressive parameter passing to jpegtran

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -30,7 +30,7 @@ module.exports = function (grunt) {
             var imagemin = new Imagemin()
                 .src(file.src[0])
                 .dest(file.dest)
-                .use(Imagemin.jpegtran(options.progressive))
+                .use(Imagemin.jpegtran({progressive: options.progressive}))
                 .use(Imagemin.gifsicle(options.interlaced))
                 .use(Imagemin.optipng(options.optimizationLevel));
 


### PR DESCRIPTION
Options to jpegtran were passed as jpegtran(true) insted of jpegtran({progressive: true}), which made progressive parameter unusable and even default setting was not working correctly.
