### PR TITLE
Suppress the compression output of individual files

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
                     msg = 'saved ' + prettyBytes(diffSize) + ' - ' + (diffSize / origSize * 100).toFixed() + '%';
                 }
 
-                grunt.log.writeln(chalk.green('✔ ') + file.src[0] + chalk.gray(' (' + msg + ')'));
+                grunt.verbose.writeln(chalk.green('✔ ') + file.src[0] + chalk.gray(' (' + msg + ')'));
                 process.nextTick(next);
             });
         }, function (err) {


### PR DESCRIPTION
I'm working with a large project, few hundreds images and I'm not really interested in logging every single file.

With this PR it's possible to set `silent: true` and send all those messages to `grunt.verbose` instead of `grunt.log`.
The total summary is still logged.
