### PR TITLE
Let grunt --force continue

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -42,7 +42,8 @@ module.exports = function (grunt) {
             
             imagemin.optimize(function (err, data) {
                 if (err) {
-                    grunt.warn(err);
+                    grunt.warn(err + ' in file ' + file.src[0]);
+                    return next();
                 }
 
                 var diffSize = origSize - data.contents.length;


### PR DESCRIPTION
In case of errors, `grunt --force` fails because 

```
Fatal error: Cannot read property 'contents' of undefined
```

I've also added the file name inside the error message, just to know which image is causing problems
