### PR TITLE
Make dependencies semver-friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,20 +15,20 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "chalk": "^1.0.0",
-    "gulp-rename": "^1.2.0",
-    "imagemin": "^4.0.0",
-    "pretty-bytes": "^1.0.1"
+    "async": "~1.5.0",
+    "chalk": "~1.1.1",
+    "gulp-rename": "~1.2.2",
+    "imagemin": "~4.0.0",
+    "pretty-bytes": "~2.0.1"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-internal": "^0.4.10",
-    "grunt-contrib-jshint": "^0.11.0",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "time-grunt": "^1.1.0"
+    "grunt": "~0.4.5",
+    "grunt-cli": "~0.1.13",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-internal": "~0.4.13",
+    "grunt-contrib-jshint": "~0.11.3",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "time-grunt": "~1.2.2"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
This package currently requires all of its dependencies using the greedy `^` version specifier, which causes breakages for users of this library whenever one of these dependencies introduces a breaking API change (ie. #330).  

This PR bumps all of the dependencies in `package.json` to their current versions, using the more-conservative `~` specifier, which should still let minor/bugfix releases through, but hopefully prevent major releases in those packages (with breaking API changes) from introducing regressions in this package.

Assuming that imagemin and friends conform to [semver](http://semver.org/) themselves, this should make `grunt-contribute-imagemin` significantly more stable, at the expense of requiring us to cut a new release whenever `imagemin` makes a major release.