### PR TITLE
Fixes #320

### DIFF
--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
                     }
 
                     var origSize = stats.size;
-                    var diffSize = origSize - ( ( data[0].contents && data[0].contents.length ) || 0 );
+                    var diffSize = origSize - ((data[0].contents && data[0].contents.length) || 0);
 
                     totalSaved += diffSize;
 

--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
                     }
 
                     var origSize = stats.size;
-                    var diffSize = origSize - data[0].contents.length;
+                    var diffSize = origSize - ( ( data[0].contents && data[0].contents.length ) || 0 );
 
                     totalSaved += diffSize;
 


### PR DESCRIPTION
Sometimes data[0].contents is returned as null. This adds a null check to avoid a runtime exception