### PR TITLE
Expose concurrency option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,12 @@ Default: `[imagemin.gifsicle(), imagemin.jpegtran(), imagemin.optipng(), imagemi
 
 These are bundled for convenience and most users will not need anything else.
 
+### concurrency
+
+Type: `number`<br>
+Default: `os.cpus().length`
+
+Control the maximum number of image optimizations that may be performed in parallel.
 
 ## License
 

--- a/tasks/imagemin.js
+++ b/tasks/imagemin.js
@@ -32,7 +32,8 @@ module.exports = grunt => {
 		const options = this.options({
 			interlaced: true,
 			optimizationLevel: 3,
-			progressive: true
+			progressive: true,
+			concurrency: os.cpus().length
 		});
 
 		if (Array.isArray(options.svgoPlugins)) {
@@ -71,7 +72,7 @@ module.exports = grunt => {
 				grunt.warn(`${err} in file ${file.src[0]}`);
 			});
 
-		pMap(this.files, processFile, {concurrency: os.cpus().length}).then(() => {
+		pMap(this.files, processFile, {concurrency: options.concurrency}).then(() => {
 			const percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;
 			let msg = `Minified ${totalFiles} ${plur('image', totalFiles)}`;
 


### PR DESCRIPTION
Allow customization of the number of parallel operations `pMap` will run, for environments with many CPUs or shared resources.